### PR TITLE
Build with latest basilcc, and add syntax error recover strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Lazy C++
+# Lzz, The Lazy C++ Compiler
 
-Lazy C++ is C++ without header files. Write code in one file and Lzz, the Lazy C++ compiler, will generate your header and source files.
+Lazy C++ is C++ without header files. Write code in one file and let Lzz generate your header and source files.
 
 Just browse the source tree for examples. Lzz is writen in Lazy C++ (and Lua)!
 
@@ -8,18 +8,18 @@ This is Lzz version 3. It is still a work progress, though it can compile itself
 
 Version 3 is extensible. The parser finite state machine (FSM) and semantic actions are not hardcoded. Instead the FSM is loaded at runtime, and semantic actions are coded in Lua. New language constructs can be added without recompiling Lzz!
 
-The parser FSM is generated using BasilCC. Since the parser runtime library, also in BasilCC, is required to build Lzz you must build BasilCC first. BasilCC is at mjspncr/basilcc.
+The FSM is generated using BasilCC (mjspncr/basilcc). Since the parser runtime library is required to build Lzz you must build BasilCC first.
 
 Follow these steps to get Lzz up and running:
 
 1. Download and build BasilCC. Note this step will require Lua 5.3. You'll also need Lzz 2.8.2 to bootstrap the build.
 
-2. Edit the makefile in this directory. Set LZZ to the Lzz 2.8.2 executable, and BASILCC_ROOT to your BasilCC directory.
+2. Edit the makefile in this directory. Set LZZ to the Lzz 2.8.2 executable, and set BASILCC_ROOT to your BasilCC directory.
 
-3. Build the lzz3 executable: make BUILD=OPT. The binary will be created in build.gcc/bin.
+3. Build lzz3: make BUILD=OPT. The binary will be created in build.gcc/bin.
 
-4. Generate the parser FSM from the Lazy C++ grammar: basilcc lzzscripts/lzz_rules.txt. The parser FSM and a file with Lua node definitions will be created in the same directory. You'll also see a file named lzz_states.txt; this is just dump of all states, very helpful when debugging parsing conflicts.
+4. Generate the parser FSM (and Lua node definitions) from the Lazy C++ grammar: basilcc lzzscripts/lzz_rules.txt.
 
-5. Set the environment variable LZZSCRIPTS to the absolute path of the lzzscripts directory. 
+5. Set the environment variable LZZSCRIPTS to the full path of the lzzscripts directory. 
 
-If you'd like to compile Lzz with binary you just built, in the makefile set LZZ to the binary and type 'make clean; make BUILD=OPT'.
+To compile Lzz with binary you just built, in the makefile set LZZ to the binary and type 'make clean; make BUILD=OPT'.

--- a/lzzscripts/lzz_rules.txt
+++ b/lzzscripts/lzz_rules.txt
@@ -4,55 +4,6 @@
 #
 #================================================================================
 
-%keyword AUTO      "auto"
-%keyword BOOL      "bool"
-%keyword CATCH     "catch"
-%keyword CHAR      "char"
-%keyword CLASS     "class"
-%keyword CONST     "const"
-%keyword DELETE    "delete"
-%keyword DINIT     "_dinit"
-%keyword DLL_API   "dll_api"
-%keyword DOUBLE    "double"
-%keyword ENUM      "enum"
-%keyword EXPLICIT  "explicit"
-%keyword EXTERN    "extern"
-%keyword FLOAT     "float"
-%keyword FRIEND    "friend"
-%keyword INLINE    "inline"
-%keyword INT       "int"
-%keyword LONG      "long"
-%keyword MUTABLE   "mutable"
-%keyword NAMESPACE "namespace"
-%keyword NEW       "new"
-%keyword OPERATOR  "operator"
-%keyword PRIVATE   "private"
-%keyword PROTECTED "protected"
-%keyword PUBLIC    "public"
-%keyword REGISTER  "register"
-%keyword SHORT     "short"
-%keyword SIGNED    "signed"
-%keyword STATIC    "static"
-%keyword STRUCT    "struct"
-%keyword TEMPLATE  "template"
-%keyword THROW     "throw"
-%keyword TRY       "try"
-%keyword TYPEDEF   "typedef"
-%keyword TYPENAME  "typename"
-%keyword UNION     "union"
-%keyword UNSIGNED  "unsigned"
-%keyword USING     "using"
-%keyword VIRTUAL   "virtual"
-%keyword VOID      "void"
-%keyword VOLATILE  "volatile"
-%keyword WCHAR     "wchar"
-
-#================================================================================
-#
-# start
-#
-#================================================================================
-
 start -> decl-seq-opt
 
 decl-seq-opt -> decl-seq
@@ -865,3 +816,58 @@ using_decl: using-decl -> USING obj-name SEMI
 
 # directive
 using_dir: using-dir -> USING NAMESPACE obj-name SEMI
+
+###
+### Keywords (these directives can be anywhere)
+###
+
+%keyword AUTO      "auto"
+%keyword BOOL      "bool"
+%keyword CATCH     "catch"
+%keyword CHAR      "char"
+%keyword CLASS     "class"
+%keyword CONST     "const"
+%keyword DELETE    "delete"
+%keyword DINIT     "_dinit"
+%keyword DLL_API   "dll_api"
+%keyword DOUBLE    "double"
+%keyword ENUM      "enum"
+%keyword EXPLICIT  "explicit"
+%keyword EXTERN    "extern"
+%keyword FLOAT     "float"
+%keyword FRIEND    "friend"
+%keyword INLINE    "inline"
+%keyword INT       "int"
+%keyword LONG      "long"
+%keyword MUTABLE   "mutable"
+%keyword NAMESPACE "namespace"
+%keyword NEW       "new"
+%keyword OPERATOR  "operator"
+%keyword PRIVATE   "private"
+%keyword PROTECTED "protected"
+%keyword PUBLIC    "public"
+%keyword REGISTER  "register"
+%keyword SHORT     "short"
+%keyword SIGNED    "signed"
+%keyword STATIC    "static"
+%keyword STRUCT    "struct"
+%keyword TEMPLATE  "template"
+%keyword THROW     "throw"
+%keyword TRY       "try"
+%keyword TYPEDEF   "typedef"
+%keyword TYPENAME  "typename"
+%keyword UNION     "union"
+%keyword UNSIGNED  "unsigned"
+%keyword USING     "using"
+%keyword VIRTUAL   "virtual"
+%keyword VOID      "void"
+%keyword VOLATILE  "volatile"
+%keyword WCHAR     "wchar"
+
+###
+### Syntax error recover strategies
+###
+
+%recover insert SEMI
+%recover insert RPAREN
+%recover discard 5

--- a/src/config/print_help.lzz
+++ b/src/config/print_help.lzz
@@ -19,7 +19,7 @@ namespace
 {
   char const version [] =
   {
-    "Lazy C++ " LZZ_VERSION
+    "Lazy C++ Compiler " LZZ_VERSION
     "\n"
   };
 


### PR DESCRIPTION
 Recover strategies added to Lzz rules file